### PR TITLE
First pass for statsd instrumentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,15 +2,16 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gem 'aws-sdk-secretsmanager'
 
-gem 'facter', '>= 1.7.0'
 gem 'metadata-json-lint'
-gem 'puppet', '>= 5.5'
+gem 'puppet', '~> 6'
 gem 'puppet-lint', '>= 1.0.0'
 gem 'puppetlabs_spec_helper', '>= 1.2.0'
 gem 'rspec-puppet'
 gem 'rubocop'
+gem 'statsd-instrument'
 
 group :development do
   gem 'pry'
   gem 'pry-rescue'
+  gem 'pry-stack_explorer', '~> 0.4'
 end

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ hierarchy:
       - "secrets/%{::environment}/"
     options:
       region: us-east-1
+      statsd: true # optional
 ```
 
 Then `lookup('myapp::database::password')` will find,
@@ -193,6 +194,12 @@ In order to conserve API calls (which are not free), lookup will list
 and cache all secret names on first execution, as well any secrets
 fetched. This is why `secretsmanager:ListSecrets` privilege is
 required.
+
+### StatsD
+
+Setting `options.statsd: true` will enable some statsd reporting using
+Shopify/statsd-instrument. If false or missing, no change in behavior
+is expected.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ An opinionated Hiera 5 `lookup_key` function for AWS Secrets Manager.
 
 Requires the `aws-sdk-secretsmanager` gem:
 
-``` shell
+```shell
 /opt/puppetlabs/puppet/bin/gem install aws-sdk-secretsmanager
 /opt/puppetlabs/server/bin/puppetserver gem install aws-sdk-secretsmanager
 ```
 
 or
 
-``` puppet
+```puppet
 package { 'aws-sdk-secretsmanager':
   ensure   => 'present',
   provider => 'puppet_gem',
@@ -38,6 +38,30 @@ package { 'aws-sdk-secretsmanager':
 package { 'aws-sdk-secretsmanager':
   ensure   => 'present',
   provider => 'puppetserver_gem',
+}
+```
+
+If you want statsd reporting, then the Shopify/statsd-instrument gem is needed too:
+
+```shell
+/opt/puppetlabs/puppet/bin/gem install statsd-instrument -v '~> 3.0.1'
+/opt/puppetlabs/server/bin/puppetserver gem install statsd-instrument -v '~> 3.0.1'
+```
+
+or
+
+```puppet
+package { 'statsd-instrument':
+  ensure   => '~> 3.0.1',
+  name     => 'statsd-instrument',
+  provider => 'puppet_gem',
+}
+
+package { 'statsd-instrument-puppetserver':
+  ensure   => '~> 3.0.1',
+  name     => 'statsd-instrument',
+  provider => 'puppetserver_gem',
+  require  => Class['puppet']
 }
 ```
 

--- a/lib/puppet/functions/hiera_aws_secretsmanager.rb
+++ b/lib/puppet/functions/hiera_aws_secretsmanager.rb
@@ -92,7 +92,13 @@ Puppet::Functions.create_function(:hiera_aws_secretsmanager) do
     return if smclient_class.class_variable_defined?(:@@__hasm_stats_setup_done)
     smclient_class.class_variable_set(:@@__hasm_stats_setup_done, true)
 
-    # Workaround for AWS SDK redefining Module.extend :table-flip-emoji:
+    begin
+      require 'statsd/instrument'
+    rescue LoadError
+      raise Puppet::DataBinding::LookupError, 'hiera_aws_secretsmanager requires the statsd-instrument gem if statsd: true'
+    end
+
+    # Workaround for AWS SDK redefining Module#extend (:table-flip-emoji:)
     smclient_class.singleton_class.include StatsD::Instrument
 
     smclient_class.statsd_count :list_secrets, 'hiera_aws_secretsmanager.list_secrets'

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,6 @@
   "source": "https://github.com/krux/hiera-aws-secretsmanager",
   "dependencies": [
     { "name": "puppetlabs-stdlib", "version_requirement": ">= 1.0.0" },
-    { "name": "statsd-instrument", "version_requirement": ">= 3.0.0 < 4.0.0" }
   ],
   "data_provider": null
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,15 +1,13 @@
 {
   "name": "krux-hiera_aws_secretsmanager",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Steven Lumos <slumos@salesforce.com>",
   "summary": "Hiera lookup_key function for AWS Secrets Manager",
   "license": "Apache-2.0",
   "source": "https://github.com/krux/hiera-aws-secretsmanager",
   "dependencies": [
-    {
-      "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 1.0.0"
-    }
+    { "name": "puppetlabs-stdlib", "version_requirement": ">= 1.0.0" },
+    { "name": "statsd-instrument", "version_requirement": ">= 3.0.0 < 4.0.0" }
   ],
   "data_provider": null
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,10 @@
+ENV['STATSD_ENV'] = 'development'
+require 'statsd/instrument'
+
 RSpec.configure do |c|
   c.mock_with :rspec
+  c.include StatsD::Instrument::Matchers
+  c.example_status_persistence_file_path = ".rspec_status"
 end
 
 require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
## What?

This change adds statsd reporting of `Aws::SecretsManager::Client#list_secrets` and `#get_secret_value`.

## Why?

The API throttling for `#list_secrets` in particular is extremely tight. This has made us want to look into reducing calls. It would be nice to know if we're succeeding!