### PR TITLE
Set `STATSD_ENV` to `production` if not already set

### DIFF
--- a/lib/puppet/functions/hiera_aws_secretsmanager.rb
+++ b/lib/puppet/functions/hiera_aws_secretsmanager.rb
@@ -92,6 +92,10 @@ Puppet::Functions.create_function(:hiera_aws_secretsmanager) do
     return if smclient_class.class_variable_defined?(:@@__hasm_stats_setup_done)
     smclient_class.class_variable_set(:@@__hasm_stats_setup_done, true)
 
+    # STATSD_ENV defaults to `development`. I don't know any other way
+    # to set it so that Hiera inside Puppet Enterprise gets it.
+    ENV['STATSD_ENV'] = 'production' unless ENV['STATSD_ENV']
+
     begin
       require 'statsd/instrument'
     rescue LoadError

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "source": "https://github.com/krux/hiera-aws-secretsmanager",
   "dependencies": [
-    { "name": "puppetlabs-stdlib", "version_requirement": ">= 1.0.0" },
+    { "name": "puppetlabs-stdlib", "version_requirement": ">= 1.0.0" }
   ],
   "data_provider": null
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,13 +1,12 @@
 {
   "name": "krux-hiera_aws_secretsmanager",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Steven Lumos <slumos@salesforce.com>",
   "summary": "Hiera lookup_key function for AWS Secrets Manager",
   "license": "Apache-2.0",
   "source": "https://github.com/krux/hiera-aws-secretsmanager",
   "dependencies": [
     { "name": "puppetlabs-stdlib", "version_requirement": ">= 1.0.0" }
-  ],
-  "data_provider": null
+  ]
 }
 


### PR DESCRIPTION
The default if not set is `development`. I do not know where to set an env var so that Hiera run by Puppet Enterprise will see it.

Also fixes a warning due to invalid json.