### PR TITLE
Add ability to tune SecretsManager backoff/retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
     * [Setup requirements](#setup-requirements)
     * [Beginning with hiera_aws_secretsmanager](#beginning-with-hiera_aws_secretsmanager)
 1. [Usage - Configuration options and additional functionality](#usage)
+    * [Notes](#notes)
+    * [Retry/Backoff](#retrybackoff)
+    * [StatsD](#statsd)
 1. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
 1. [Limitations - OS compatibility, etc.](#limitations)
 1. [Development - Guide for contributing to the module](#development)
@@ -200,6 +203,9 @@ hierarchy:
     options:
       region: us-east-1
       statsd: true # optional
+      retries: # optional
+        retry_mode: adaptive
+        max_attempts: 10
 ```
 
 Then `lookup('myapp::database::password')` will find,
@@ -212,18 +218,27 @@ Manager and return its `secret_string` attribute.
 2. Getting `$AWS_REGION` set in the context of the catalog compile
    turns out to be a pain, so the `region` option is required for now.
 
+#### Retry/Backoff
+
+It is possible to configure the AWS SDK retry/backoff by adding a
+`options.retries` hash. Its value is passed to the AWS SDK with
+minimal sanity checking. See the [Aws::SecretsManager::Client#initialize]
+documentation for allowed values.
+
+[Aws::SecretsManager::Client#initialize]: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SecretsManager/Client.html#initialize-instance_method
+
+#### StatsD
+
+Setting `options.statsd: true` will enable some statsd reporting using
+Shopify/statsd-instrument. If false or missing, no change in behavior
+is expected.
+
 ### Caching
 
 In order to conserve API calls (which are not free), lookup will list
 and cache all secret names on first execution, as well any secrets
 fetched. This is why `secretsmanager:ListSecrets` privilege is
 required.
-
-### StatsD
-
-Setting `options.statsd: true` will enable some statsd reporting using
-Shopify/statsd-instrument. If false or missing, no change in behavior
-is expected.
 
 ## Limitations
 

--- a/lib/puppet/functions/hiera_aws_secretsmanager.rb
+++ b/lib/puppet/functions/hiera_aws_secretsmanager.rb
@@ -83,7 +83,9 @@ Puppet::Functions.create_function(:hiera_aws_secretsmanager) do
   end
 
   def smclient_options
-    retry_options.merge(region: @options['region'])
+    smclient_options = {region: @options['region']}
+    smclient_options.merge!(retry_options)
+    @context.explain { "Aws::SecretsManager::Client options: #{smclient_options}" }
   end
 
   # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SecretsManager/Client.html#initialize-instance_method

--- a/lib/puppet/functions/hiera_aws_secretsmanager.rb
+++ b/lib/puppet/functions/hiera_aws_secretsmanager.rb
@@ -76,10 +76,34 @@ Puppet::Functions.create_function(:hiera_aws_secretsmanager) do
         raise ArgumentError, 'options: {region: ...} must be set in hiera.yaml'
       end
 
-      @context.cache(SMCLIENT_KEY, Aws::SecretsManager::Client.new(region: @options['region']))
+      @context.cache(SMCLIENT_KEY, Aws::SecretsManager::Client.new(smclient_options))
     end
 
     @context.cached_value(SMCLIENT_KEY)
+  end
+
+  def smclient_options
+    retry_options.merge(region: @options['region'])
+  end
+
+  # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SecretsManager/Client.html#initialize-instance_method
+  def retry_options
+    return {} unless @options['retries']
+
+    allowed_opts = %w[
+      adaptive_retry_wait_to_fill
+      max_attempts
+      retry_backoff
+      retry_base_delay
+      retry_jitter
+      retry_limit
+      retry_max_delay
+      retry_mode
+    ]
+
+    @options['retries']
+      .select { |opt, _| allowed_opts.member?(opt) }
+      .transform_keys!(&:to_sym)
   end
 
   def setup_stats_if_enabled

--- a/lib/puppet/functions/hiera_aws_secretsmanager.rb
+++ b/lib/puppet/functions/hiera_aws_secretsmanager.rb
@@ -86,6 +86,7 @@ Puppet::Functions.create_function(:hiera_aws_secretsmanager) do
     smclient_options = {region: @options['region']}
     smclient_options.merge!(retry_options)
     @context.explain { "Aws::SecretsManager::Client options: #{smclient_options}" }
+    smclient_options
   end
 
   # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SecretsManager/Client.html#initialize-instance_method

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "krux-hiera_aws_secretsmanager",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": "Steven Lumos <slumos@salesforce.com>",
   "summary": "Hiera lookup_key function for AWS Secrets Manager",
   "license": "Apache-2.0",

--- a/spec/functions/lookup_key_spec.rb
+++ b/spec/functions/lookup_key_spec.rb
@@ -16,6 +16,10 @@ describe :hiera_aws_secretsmanager do
       'uri' => 'test/secret/path',
       'region' => 'us-east-1',
       'statsd' => true,
+      'retries' => {
+        'retry_mode' => 'adaptive',
+        'max_attempts' => 10,
+      }
     }
   }
 


### PR DESCRIPTION
# What

Adds the ability to tune AWS SDK retry options by adding a `retries` block to `hiera.yaml`. E.g.
```yaml
...
    options:
      region: 'us-east-1'
      statsd: true
      retries:
        retry_mode: adaptive
        max_attempts: 10
...
```

# Why

This will hopefully allow us to better manage certain scenarios where we get throttled by the ListSecrets API.